### PR TITLE
Fix parsing BSDLs where the port is terminated in the same line

### DIFF
--- a/translate2geda.java
+++ b/translate2geda.java
@@ -793,6 +793,9 @@ public class translate2geda {
                 endOfPinDef = true;
               } else {
                 portPinDef.add(currentLine);
+                if (currentLine.endsWith(");")) {
+                  endOfPinDef = true;
+                }
               }
             }
           }


### PR DESCRIPTION
Hi @erichVK5 

many thanks for this tool!

I came across a BSDL:
https://bsdl.info/view.htm?sid=60458d52ec2699e688ca59b002289d77

Where the ports section was terminated with a ); in the same line as the pin:
```

	            D7:	inout	bit;
	            D8:	inout	bit;
	            D9:	inout	bit);   <--

	use STD_1149_1_1994.all;
```

Rather than fixing the BSDL I fixed the code to handle this case.